### PR TITLE
Use NSWorkspace instead of SBApplication in Open terminal.sketchplugin

### DIFF
--- a/Git/Open terminal.sketchplugin
+++ b/Git/Open terminal.sketchplugin
@@ -2,10 +2,6 @@
 
 #import 'library/common.js'
 
-var currentFolder = com.bomberstudios.getFileFolder()
-
-var terminal = SBApplication.application_("Terminal");
-
-terminal.doScript_in_("cd " + currentFolder + "; cd ../;",nil);
-
-terminal.activate();
+var path = com.bomberstudios.getCurrentDirectory();
+NSWorkspace.sharedWorkspace()
+           .openFile_withApplication_(path, @"Terminal");

--- a/library/common.js
+++ b/library/common.js
@@ -19,6 +19,9 @@ com.bomberstudios = {
         file_folder = file_path
     return file_folder;
   },
+  getCurrentDirectory: function() {
+    return [[[doc fileURL] URLByDeletingLastPathComponent] path];
+  },
   getExportPath: function(){
     var file_folder = com.bomberstudios.getFileFolder(),
         export_folder = file_folder + "/" + ([doc displayName]).split('.sketch')[0] + "_export/";


### PR DESCRIPTION
- Use NSWorkspace instead of SBApplication in Open terminal.sketchplugin(fix almonk/SketchGit#6)
